### PR TITLE
Better error messages when raising exceptions.

### DIFF
--- a/lib/roomorama_api.rb
+++ b/lib/roomorama_api.rb
@@ -12,14 +12,22 @@ require_relative 'roomorama_api/client'
 
 module RoomoramaApi
 
-  class Error < RuntimeError ; end
+  class NetworkError < StandardError
+    def initialize(status, body)
+      super("Error. HTTP status: #{status}. Response body: #{msg}")
+    end
+  end
 
-  class EndpointNotImplemented < Error ; end
+  class UnauthorizedRequest < NetworkError; end
+  class NotFound < NetworkError; end
+  class ApiNotResponding < NetworkError; end
+  class InvalidRequest < NetworkError; end
+  class UnexpectedResponse < NetworkError; end
 
-  class UnauthorizedRequest < Error ; end
-  class NotFound < Error ; end
-  class ApiNotResponding < Error ; end
-  class InvalidRequest < Error ; end
-  class UnexpectedResponse < Error ; end
+  class EndpointNotImplemented < StandardError
+    def initialize(endpoint)
+      super("Unrecognized endpoint: #{endpoint}")
+    end
+  end
 
 end


### PR DESCRIPTION
So far, when we HTTP status is not successful, we already raise a
contextualized exception. However, only that is not enough to easily
debug the issue, since the actual HTTP status and body message are not
known.

This aims to make it easier to debug unsuccessful API responses by
providing more information when raising exceptions.