### PR TITLE
Use proper endpoint when making a property instantly available.

### DIFF
--- a/lib/roomorama_api/host/properties.rb
+++ b/lib/roomorama_api/host/properties.rb
@@ -472,10 +472,12 @@ module RoomoramaApi
       #     "instant_booking"=>true
       #   }
       def set_instantly_available(property_hash)
-        property_hash.merge(api_version: "v2.0")
         instantly_available = property_hash.fetch(:instantly_available)
-        url = host_instantly_available_url(property_hash)
-        instantly_available ? auth_post(url) : auth_delete(url)
+        url = host_property_url(property_hash)
+        data = property_hash
+        data = data.merge(instant_booking: !!instantly_available)
+
+        auth_put(url, data)
       end
 
       # Returns the units for a specified room

--- a/lib/roomorama_api/version.rb
+++ b/lib/roomorama_api/version.rb
@@ -1,0 +1,3 @@
+module RoomoramaApi
+  VERSION = '0.0.5'
+end

--- a/roomorama_api.gemspec
+++ b/roomorama_api.gemspec
@@ -1,6 +1,8 @@
+require "roomorama_api/version"
+
 Gem::Specification.new do |s|
   s.name  = 'roomorama_api'
-  s.version = '0.0.4'
+  s.version = RoomoramaApi::VERSION
   s.date    = '2014-11-02'
   s.summary = "Roomorama Api Client - Ruby wrapper library to consume Roomorama's API 1.0"
   s.description = "Roomorama Api Client - Ruby wrapper library to consume Roomorama's API 1.0"


### PR DESCRIPTION
Updates the endpoint for marking a property as instantly available according to the report on https://github.com/roomorama/roomorama-api/issues/20.

@sharipov-ru can you help me verify that this fixes your problem?